### PR TITLE
Added url parameter to specify a different server

### DIFF
--- a/examples/testdata/generate_testdata.py
+++ b/examples/testdata/generate_testdata.py
@@ -70,6 +70,7 @@ def generate_point_data(n):
 # main program
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate test datasets for the experiments')
+    parser.add_argument('-url', type=str, default='https://dev.archaeology.datastations.nl', help='Server URL')
     parser.add_argument('-n', type=int, default=1, help='Number of datasets')
     parser.add_argument('-a', type=str, help='API token', required=True)
     # output is not used now
@@ -79,7 +80,7 @@ if __name__ == '__main__':
     
     # TODO: parse from command line
     parent = 'root'
-    server_url = 'https://dev.archaeology.datastations.nl'
+    server_url = args.url #'https://dev.archaeology.datastations.nl'
     api_token = args.a 
     n = args.n
     output = args.output

--- a/examples/testdata/generate_testdata.py
+++ b/examples/testdata/generate_testdata.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     
     # TODO: parse from command line
     parent = 'root'
-    server_url = args.url #'https://dev.archaeology.datastations.nl'
+    server_url = args.url
     api_token = args.a 
     n = args.n
     output = args.output


### PR DESCRIPTION
You can now specify a server url when generating test datsets; 
```
python3 examples/testdata/generate_testdata.py -url 'https://demo.archaeology.datastations.nl' -n 200 -a "some-api-key-here"
```
Will add them to the demo server; 
remember to disable all those notifications for dataset create, publish, and workflow. Otherwise you will be spammed...
