### PR TITLE
Skip spatialPoint if it has no Scheme

### DIFF
--- a/examples/custom-footer.html
+++ b/examples/custom-footer.html
@@ -90,7 +90,7 @@
 }
 </style>
 <!-- DvDatasetGeoMapViewer, when deployed on a DANS server the js file should be in '/var/www/html/custom' -->
-<script src="/custom/geomapview/dv-dataset-geomap-view-0.3.0.js"></script>
+<script src="/custom/geomapview/dv-dataset-geomap-view-0.3.1.js"></script>
 <script>
 // Assume we have jQuery, because its is in the footer of the Dataverse application
 $().ready(function() {

--- a/examples/dataverse.html
+++ b/examples/dataverse.html
@@ -81,7 +81,7 @@
 }
 </style>
 <!-- DvDatasetGeoMapViewer, when deployed on a DANS server the js file should be in '/var/www/html/custom' -->
-<script src="./dv-dataset-geomap-view-0.3.0.js"></script>
+<script src="./dv-dataset-geomap-view-0.3.1.js"></script>
 <script>
 // Assume we have jQuery, because its is in the footer of the Dataverse application
 $().ready(function() {

--- a/src/dv-dataset-geomap-view-0.3.1.js
+++ b/src/dv-dataset-geomap-view-0.3.1.js
@@ -481,20 +481,27 @@ let dansDvGeoMap = (function() {
                 // Note that there could be multiple points, even in different schemes
                 if (typeof dansSpatialPoint !== "undefined") {
                     for (let i = 0; i < dansSpatialPoint.value.length; i++) {
+                        if (dansSpatialPoint.value[i]["dansSpatialPointScheme"] === undefined ||
+                            dansSpatialPoint.value[i]["dansSpatialPointScheme"].value  === undefined ) {
+                                console.warn('Invalid dansSpatialPoint: Missing Scheme for: ' + value.global_id);
+                            continue;
+                        }
+                        let dansSpatialPointScheme = dansSpatialPoint.value[i]["dansSpatialPointScheme"].value;
+
                         dansSpatialPointX = dansSpatialPoint.value[i]["dansSpatialPointX"].value;
                         dansSpatialPointY = dansSpatialPoint.value[i]["dansSpatialPointY"].value;
                         let lat = 0;
                         let lon = 0;
-                        if (dansSpatialPoint.value[i]["dansSpatialPointScheme"].value === "RD (in m.)") {
+                        if (dansSpatialPointScheme === "RD (in m.)") {
                             latLon = convertRDtoWGS84(parseFloat(dansSpatialPointX), parseFloat(dansSpatialPointY));
                             lat = latLon.lat;
                             lon = latLon.lon;
-                        } else if ( dansSpatialPoint.value[i]["dansSpatialPointScheme"].value === "longitude/latitude (degrees)") {
+                        } else if ( dansSpatialPointScheme === "longitude/latitude (degrees)") {
                             // Assume WGS84 in decimal degrees, no conversion needed
                             lat = parseFloat(dansSpatialPointY);
                             lon = parseFloat(dansSpatialPointX);
                         } else {    
-                            console.warn('Spatial point scheme not recognized: ' + dansSpatialPoint.value[i]["dansSpatialPointScheme"].value);
+                            console.warn('Spatial point scheme not recognized: ' + dansSpatialPointScheme);
                             continue; // skip this point, because we don't know how to convert!
                         }
 


### PR DESCRIPTION
Fixes a problem with the map not having the markers rendered (spinner keeps going, maps stays empty)  
This happens if a `dansSpatialPoint` does not have a `dansSpatialPointScheme`  with a `value`. 
The input form allows this, you need to publish for it to get it on the map; also sort on 'newest'. 
The fix simply test for the existence and skips the point if it has no scheme. 

Note that the version in the filename is now 0.3.1!
